### PR TITLE
Rename to ZSH_LLM_SUGGESTIONS_OPENROUTER_MODEL, default to claude-3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ For `zsh_llm_suggestions_openrouter` (OpenRouter-based suggestions):
   ```
   export OPENROUTER_API_KEY="..."
   ```
-- Optionally, set the `OPENROUTER_MODEL` environment variable to specify which model to use:
+- Optionally, set the `ZSH_LLM_SUGGESTIONS_OPENROUTER_MODEL` environment variable to specify which model to use:
   ```
-  export OPENROUTER_MODEL="openrouter/anthropic/claude-3.5-sonnet:beta"
+  export ZSH_LLM_SUGGESTIONS_OPENROUTER_MODEL="openrouter/anthropic/claude-3.7-sonnet"
   ```
-  If not set, the default model "openrouter/anthropic/claude-3.5-sonnet:beta" will be used.
+  If not set, the default model "openrouter/anthropic/claude-3.7-sonnet" will be used.
 - Alternatively, you can store your API key using `secret-tool`:
   ```
   secret-tool store --label='OpenRouter API Key' service openrouter.ai
@@ -140,4 +140,4 @@ There are some risks using `zsh-llm-suggestions`:
 Currently, three LLMs are supported:
 1. GitHub Copilot (via GitHub CLI). Requires a GitHub Copilot subscription.
 2. OpenAI. Requires an OpenAI API key. Currently uses `gpt-4-1106-preview`.
-3. OpenRouter. Requires an OpenRouter API key. Uses the model specified by the `OPENROUTER_MODEL` environment variable, or falls back to "openrouter/anthropic/claude-3.5-sonnet:beta" if not set.
+3. OpenRouter. Requires an OpenRouter API key. Uses the model specified by the `ZSH_LLM_SUGGESTIONS_OPENROUTER_MODEL` environment variable, or falls back to "openrouter/anthropic/claude-3.7-sonnet" if not set.

--- a/zsh-llm-suggestions-openrouter.py
+++ b/zsh-llm-suggestions-openrouter.py
@@ -46,9 +46,9 @@ You should only output the completed command, no need to include any other expla
         system_message = """You are a zsh shell expert, please briefly explain how the given command works. Be as concise as possible. Use Markdown syntax for formatting."""
 
     # Default model if environment variable is not set
-    default_model = "openrouter/anthropic/claude-3.5-sonnet:beta"
+    default_model = "openrouter/anthropic/claude-3.7-sonnet"
     # Get model from environment variable or use default
-    model_name = os.environ.get("OPENROUTER_MODEL", default_model)
+    model_name = os.environ.get("ZSH_LLM_SUGGESTIONS_OPENROUTER_MODEL", default_model)
 
     try:
         model = llm.get_model(model_name)
@@ -64,8 +64,8 @@ You should only output the completed command, no need to include any other expla
             f"Error: The specified model '{model_name}' is not supported or not found."
         )
         print(
-            "Please check the model name or use the default model"
-            " by unsetting the OPENROUTER_MODEL environment variable."
+            "Please check the model name or use the default model by"
+            " unsetting the ZSH_LLM_SUGGESTIONS_OPENROUTER_MODEL environment variable."
         )
         return
     except Exception as e:


### PR DESCRIPTION
- Renamed OPENROUTER_MODEL environment variable to ZSH_LLM_SUGGESTIONS_OPENROUTER_MODEL for better namespace consistency
- Updated default model from Claude 3.5 to Claude 3.7 (openrouter/anthropic/claude-3.7-sonnet)
- Updated documentation in README.md to reflect these changes